### PR TITLE
Ignore punctuation after a username in whois

### DIFF
--- a/whois.go
+++ b/whois.go
@@ -11,7 +11,7 @@ import (
 	"github.com/danryan/hal"
 )
 
-var whoisHandler = hear(`who\s?is (.+)`, func(res *hal.Response) error {
+var whoisHandler = hear(`who\s?is ([A-Za-z0-9\-_\{\}\[\]\\]+)`, func(res *hal.Response) error {
 	name := res.Match[1]
 	key := strings.ToUpper(name)
 	val, err := res.Robot.Store.Get(key)


### PR DESCRIPTION
This commit addresses issue #10. So, `Ash who is someone?` returns `someone is no one to me`.
